### PR TITLE
use documentElement instead of body to detect css3 animations

### DIFF
--- a/plugin/src/jquery.stackbox.js
+++ b/plugin/src/jquery.stackbox.js
@@ -1296,13 +1296,13 @@
             domPrefixes = 'Webkit Moz O ms Khtml'.split(' '),
             pfx = '';
 
-        if (document.body.style.animationName !== undefined) {
+        if (document.documentElement.style.animationName !== undefined) {
             css3animsupported = true;
         }
 
         if (css3animsupported === false) {
             for (var i = 0; i < domPrefixes.length; i++) {
-                if (document.body.style[domPrefixes[i] + 'AnimationName'] !== undefined) {
+                if (document.documentElement.style[domPrefixes[i] + 'AnimationName'] !== undefined) {
                     pfx = domPrefixes[i];
                     animationstring = pfx + 'Animation';
                     keyframeprefix = '-' + pfx.toLowerCase() + '-';


### PR DESCRIPTION
Thank you for the wonderful plugin.

I am using stackbox in a Rails application. When stackbox is loaded in the asset pipeline, body is not yet loaded. Hence, the CSS3 animation detection code returns

```javascript
document.body is null
```